### PR TITLE
Specify filename for files submitted as data URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ user = User.find 123
 user.avatar_data_uri = 'data:image/gif;base64,R0lGODlhAQABAJEAAAAAAP////8AAP///yH5BAEAAAMALAAAAAABAAEAAAICVAEAOw=='
 user.save
 ```
+
+Optionally, to customize the file name, specify the `#{column}_data_filename` attribute before the `#{column}_data_uri` attribute.
+
+```ruby
+user = User.find 123
+user.avatar_data_filename = 'somefile.jpg'
+user.avatar_data_uri = 'data:image/gif;base64,R0lGODlhAQABAJEAAAAAAP////8AAP///yH5BAEAAAMALAAAAAABAAEAAAICVAEAOw=='
+user.save
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/carrierwave-data-uri/fork )

--- a/lib/carrierwave-data-uri.rb
+++ b/lib/carrierwave-data-uri.rb
@@ -1,5 +1,6 @@
 require 'carrierwave'
 require 'carrierwave/orm/activerecord'
+require 'carrierwave_data_uri/tempfile'
 require 'carrierwave_data_uri/parser'
 require 'carrierwave_data_uri/version'
 require 'carrierwave_data_uri/mount'

--- a/lib/carrierwave_data_uri/mount.rb
+++ b/lib/carrierwave_data_uri/mount.rb
@@ -8,8 +8,10 @@ module CarrierWave
         super
 
         class_eval <<-RUBY, __FILE__, __LINE__+1
+          attr_accessor :#{column}_data_filename
+
           def #{column}_data_uri=(data)
-            self.#{column} = Parser.new(data).to_file
+            self.#{column} = Parser.new(data).to_file original_filename: self.#{column}_data_filename
           end
         RUBY
       end

--- a/lib/carrierwave_data_uri/parser.rb
+++ b/lib/carrierwave_data_uri/parser.rb
@@ -1,4 +1,3 @@
-require 'tempfile'
 require 'base64'
 
 module CarrierWave
@@ -21,12 +20,13 @@ module CarrierWave
         @binary_data ||= Base64.decode64 data
       end
 
-      def to_file
+      def to_file(options = {})
         @file ||= begin
           file = Tempfile.new ['data_uri_upload', ".#{extension}"]
           file.binmode
           file << binary_data
           file.rewind
+          file.original_filename = options[:original_filename]
           file
         end
       end

--- a/lib/carrierwave_data_uri/tempfile.rb
+++ b/lib/carrierwave_data_uri/tempfile.rb
@@ -1,0 +1,13 @@
+require 'tempfile'
+
+module CarrierWave
+  module DataUri
+    class Tempfile < ::Tempfile
+      attr_writer :original_filename
+
+      def original_filename
+        @original_filename || File.basename(@tmpname)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Extend ruby's Tempfile
  - Allow assignment of `original_filename` attribute
  - Respond to `original_filename` with either the assigned instance variable, or the Tempfile's basename
- Add optional filename attribute to the mounted uploader
- Change Parser's `to_file` method to accept options, the only one of which currently being used is original_filename
- Pass the original_filename from the mounted uploader to Parser
- Update the README
