### PR TITLE
rails 5 @tmpname nil

### DIFF
--- a/lib/carrierwave_data_uri/tempfile.rb
+++ b/lib/carrierwave_data_uri/tempfile.rb
@@ -6,7 +6,7 @@ module CarrierWave
       attr_writer :original_filename
 
       def original_filename
-        @original_filename || File.basename(@tmpname)
+        @original_filename || File.basename(path)
       end
     end
   end


### PR DESCRIPTION
the `original_filename` method was raising an exception if `{column}_data_filename =` was not set before trying to save the data uri. This pull request addresses that by defaulting to the name of the tempfile instead of `@tmpname`, which was nil.
