### PR TITLE
Use data_uri for parsing file data

### DIFF
--- a/carrierwave-data-uri.gemspec
+++ b/carrierwave-data-uri.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'carrierwave'
+  spec.add_dependency 'data_uri'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/carrierwave_data_uri/parser.rb
+++ b/lib/carrierwave_data_uri/parser.rb
@@ -1,4 +1,4 @@
-require 'base64'
+require 'data_uri'
 
 module CarrierWave
   module DataUri
@@ -6,18 +6,16 @@ module CarrierWave
       attr_reader :type, :encoder, :data, :extension
 
       def initialize(data_uri)
-        if data_uri.match /^data:(.*?);(.*?),(.*)$/
-          @type = $1
-          @encoder = $2
-          @data = $3
-          @extension = $1.split('/')[1]
-        else
-          raise ArgumentError, 'Cannot parse data'
-        end
+        uri = URI::Data.new data_uri
+        @type = uri.content_type
+        @extension = @type.split('/')[1]
+        @data = uri.data
+      rescue URI::InvalidURIError => e
+        raise ArgumentError, 'Cannot parse data'
       end
 
       def binary_data
-        @binary_data ||= Base64.decode64 data
+        @data
       end
 
       def to_file(options = {})


### PR DESCRIPTION
Add [data_uri](https://github.com/dball/data_uri) gem as a dependency.
- Improves memory efficiency (data_uri checks for pieces of the file, not the entire file)
- Only decodes base64 data if the file was originally base64 encoded (should allow for SVG upload)
