### PR TITLE
Add attr_accessor `_data_uri` and `_data_url_cache`

### DIFF
--- a/lib/carrierwave_data_uri/mount.rb
+++ b/lib/carrierwave_data_uri/mount.rb
@@ -9,10 +9,12 @@ module CarrierWave
 
         class_eval <<-RUBY, __FILE__, __LINE__+1
           attr_accessor :#{column}_data_uri
+          attr_accessor :#{column}_data_uri_cache
           attr_accessor :#{column}_data_filename, :#{column}_data_mimetype
 
           def #{column}_data_uri=(data)
             return if data.blank?
+            self.#{column}_data_uri_cache = data
             self.#{column} = Parser.new(data).to_file original_filename: self.#{column}_data_filename, content_type: self.#{column}_data_mimetype
           end
         RUBY

--- a/lib/carrierwave_data_uri/mount.rb
+++ b/lib/carrierwave_data_uri/mount.rb
@@ -8,9 +8,11 @@ module CarrierWave
         super
 
         class_eval <<-RUBY, __FILE__, __LINE__+1
+          attr_accessor :#{column}_data_uri
           attr_accessor :#{column}_data_filename, :#{column}_data_mimetype
 
           def #{column}_data_uri=(data)
+            return if data.blank?
             self.#{column} = Parser.new(data).to_file original_filename: self.#{column}_data_filename, content_type: self.#{column}_data_mimetype
           end
         RUBY

--- a/lib/carrierwave_data_uri/mount.rb
+++ b/lib/carrierwave_data_uri/mount.rb
@@ -9,12 +9,11 @@ module CarrierWave
 
         class_eval <<-RUBY, __FILE__, __LINE__+1
           attr_accessor :#{column}_data_uri
-          attr_accessor :#{column}_data_uri_cache
           attr_accessor :#{column}_data_filename, :#{column}_data_mimetype
 
           def #{column}_data_uri=(data)
             return if data.blank?
-            self.#{column}_data_uri_cache = data
+            @#{column}_data_uri = data
             self.#{column} = Parser.new(data).to_file original_filename: self.#{column}_data_filename, content_type: self.#{column}_data_mimetype
           end
         RUBY


### PR DESCRIPTION
I want to use `_data_uri` column on `html form (not ajax)`.

First.
If without `attr_accessor :#{column}_data_uri`.
There is need to add `attr_accessor` declaration every model which use `carrierwave_data_uri`.

Second.
In case of html form like above.
If other column is invalid. Rails's form is render again as `edit`.
Then I want a `cache` column to restore `dataURI` data to `_data_uri` from `_data_uri_cache`.

Sorry my english.

thanks.


